### PR TITLE
Add latest_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can also specify the boundaries when you invoke the function to get a custom
 ```python
 levi.delta_file_sizes(dt, ["<1mb", "1mb-200mb", "200mb-800mb", "800mb-2gb", ">2gb"])
 ```
+
+## Get Latest Delta Table Version
+
+The `latest_version` function gets the most current Delta Table version number and returns it.
+
+```python
+import levi
+from deltalake import DeltaTable
+
+dt = DeltaTable("some_folder/some_table")
+levi.latest_version(dt)
+
+# return value
+2
+```
+

--- a/levi/__init__.py
+++ b/levi/__init__.py
@@ -1,7 +1,12 @@
 import re
+from deltalake import DeltaTable
 
 
-def delta_file_sizes(delta_table, boundaries=None):
+def latest_version(delta_table: DeltaTable):
+    return delta_table.version()
+
+
+def delta_file_sizes(delta_table: DeltaTable, boundaries=None):
     if boundaries is None:
         boundaries = ["<1mb", "1mb-500mb", "500mb-1gb", "1gb-2gb", ">2gb"]
     df = delta_table.get_add_actions(flatten=True).to_pandas()

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -1,12 +1,21 @@
 import levi
 from deltalake import DeltaTable
 
+
 def test_delta_file_sizes():
     dt = DeltaTable("./tests/reader_tests/generated/basic_append/delta")
     print(levi.delta_file_sizes(dt))
     res = levi.delta_file_sizes(dt, ["<300b", "300b-1kb", "1kb-100kb", ">100kb"])
     expected = {'num_files_<300b': 0, 'num_files_300b-1kb': 2, 'num_files_1kb-100kb': 0, 'num_files_>100kb': 0}
     assert res == expected
+
+
+def test_latest_version():
+    dt = DeltaTable("./tests/reader_tests/generated/multi_partitioned/delta")
+    res = levi.latest_version(dt)
+    expected = 2
+    assert res == expected
+
 
 def test_str_to_bytes():
     assert levi.str_to_bytes("100b") == 100


### PR DESCRIPTION
It is essentially only wrapping the `version` function and not adding any funcitonality, but I think it is fine, since `version` is a little bit vague and not that explicit, where as `latest_version` is more obvious to the end-user I think.