### PR TITLE
added drop_duplicates and drop_duplicates_pkey + unit tests

### DIFF
--- a/levi/__init__.py
+++ b/levi/__init__.py
@@ -1,12 +1,12 @@
 import re
-from typing import Optional, List, Iterable, Dict, Union, Tuple
+from typing import Optional, List, Union, Tuple
 from deltalake import DeltaTable, write_deltalake
 import datetime
 import numpy as np
 import pyarrow as pa
 from pyarrow.interchange.from_dataframe import DataFrameObject
 import pyarrow.compute as pc 
-import collections
+
 
 def skipped_stats(delta_table, filters):
     df = delta_table.get_add_actions(flatten=True).to_pandas()
@@ -112,6 +112,7 @@ def updated_partitions(delta_table: DeltaTable, start_time: Optional[datetime.da
         add_actions_df = add_actions_df[add_actions_df["modification_time"] < np.datetime64(int(end_time.timestamp() * 1e6), "us")]
 
     return add_actions_df.drop_duplicates(subset=["partition_values"])["partition_values"].tolist()
+
 
 def type_2_scd_upsert(
         delta_table: DeltaTable,
@@ -240,6 +241,7 @@ def type_2_scd_upsert(
             predicate=' or '.join([f"source.{col} != target.{col}" for col in attr_col_names])
         ).execute()
     )
+
 
 def drop_duplicates(delta_table: DeltaTable, duplication_columns: Union[List[str],Tuple[str]]) -> None:
     """

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -123,6 +123,7 @@ def test_updated_partitions_without_time_filter(tmp_path: Path):
 
     assert updated_partitions == [{"partition_1": 1, "partition_2": "a"}, {"partition_1": 2, "partition_2": "b"}]
 
+
 def test_updated_partitions_with_time_filter(tmp_path: Path):
     table_location = tmp_path / "test_table"
 
@@ -153,6 +154,7 @@ def test_updated_partitions_with_time_filter(tmp_path: Path):
     updated_partitions = levi.updated_partitions(delta_table, start_time, end_time)
 
     assert updated_partitions == [{"partition_1": 1, "partition_2": "a"}]
+
 
 def test_type_2_scd_upsert_with_single_attribute(tmp_path: Path):
     path = f"{tmp_path}/tmp/delta-upsert-single_attr"
@@ -223,6 +225,7 @@ def test_type_2_scd_upsert_with_single_attribute(tmp_path: Path):
     sorted_expected_table = expected_table.take(expected_table_sort_indices)
 
     assert sorted_actual_table == sorted_expected_table
+
 
 def test_type_2_scd_upsert_with_multiple_attributes(tmp_path: Path):
     path = f"{tmp_path}/tmp/delta-upsert-single_attr"
@@ -406,7 +409,6 @@ def test_type_2_scd_upsert_errors_out_if_updates_df_does_not_have_all_required_c
         )
 
 
-
 def test_type_2_scd_upsert_does_not_insert_duplicate(tmp_path: Path):
     path = f"{tmp_path}/tmp/delta-upsert-single_attr"
         
@@ -477,7 +479,6 @@ def test_type_2_scd_upsert_does_not_insert_duplicate(tmp_path: Path):
     sorted_expected_table = expected_table.take(expected_table_sort_indices)
 
     assert sorted_actual_table == sorted_expected_table
-
 
 
 def test_type_2_scd_upsert_with_version_number(tmp_path: Path):
@@ -551,7 +552,6 @@ def test_type_2_scd_upsert_with_version_number(tmp_path: Path):
     assert sorted_actual_table == sorted_expected_table
 
 def test_drop_duplicates_one_column(tmp_path):
-
     path = f"{tmp_path}/drop_duplicates1"
 
     schema = pa.schema([
@@ -591,8 +591,8 @@ def test_drop_duplicates_one_column(tmp_path):
         schema=schema
     )
 
-
     assert actual_pyarrow_table == expected_pyarrow_table
+
 
 def test_drop_duplicates_two_columns(tmp_path):
 
@@ -637,6 +637,7 @@ def test_drop_duplicates_two_columns(tmp_path):
 
     assert actual_pyarrow_table == expected_pyarrow_table
 
+
 def test_drop_duplicates_raises_errors(tmp_path):
 
     path = f"{tmp_path}/drop_duplicates2"
@@ -663,7 +664,6 @@ def test_drop_duplicates_raises_errors(tmp_path):
 
     delta_table = DeltaTable(path)
 
-
     with pytest.raises(TypeError):
         levi.drop_duplicates(None, ["col1","col2"])             # No delta_table provided
         levi.drop_duplicates(delta_table, [])                   # Empty duplication_columns provided
@@ -672,9 +672,7 @@ def test_drop_duplicates_raises_errors(tmp_path):
         levi.drop_duplicates(delta_table, "col1")               # Wrong type of duplication_columns
 
 
-
 def test_drop_duplicates_pkey_two_columns_with_sorted_pkey(tmp_path):
-
     path = f"{tmp_path}/drop_duplicates_pkey1"
 
     schema = pa.schema([
@@ -714,9 +712,7 @@ def test_drop_duplicates_pkey_two_columns_with_sorted_pkey(tmp_path):
         schema=schema
     )
 
-
     assert actual_pyarrow_table == expected_pyarrow_table
-
 
 
 def test_drop_duplicates_pkey_two_columns_with_unsorted_pkey(tmp_path):
@@ -762,7 +758,7 @@ def test_drop_duplicates_pkey_two_columns_with_unsorted_pkey(tmp_path):
 
     assert actual_pyarrow_table == expected_pyarrow_table
 
-#TODO:
+
 def test_drop_duplicates_pkey_with_unique_pkey(tmp_path):
 
     path = f"{tmp_path}/drop_duplicates_pkey1"
@@ -808,7 +804,6 @@ def test_drop_duplicates_pkey_with_unique_pkey(tmp_path):
 
 
 def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
-
     path = f"{tmp_path}/drop_duplicates_pkey1"
 
     schema = pa.schema([
@@ -837,8 +832,8 @@ def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
     with pytest.raises(ValueError):
         levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
 
-def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
 
+def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
     path = f"{tmp_path}/drop_duplicates_pkey1"
 
     schema = pa.schema([

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -549,3 +549,357 @@ def test_type_2_scd_upsert_with_version_number(tmp_path: Path):
     sorted_expected_table = expected_table.take(expected_table_sort_indices)
 
     assert sorted_actual_table == sorted_expected_table
+
+def test_drop_duplicates_one_column(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [1, 1, 1, 1],
+        "col2": ["A", "A", "A", "A"],
+        "col3": ["A", "A", "A", "A"],
+        "col4": ["C", "C", "C", "C"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    levi.drop_duplicates(delta_table, ["col1"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+
+    expected_pyarrow_table = pa.Table.from_pydict(
+        {
+            "col1": [1],
+            "col2": ["A"],
+            "col3": ["A"],
+            "col4": ["C"],
+        },
+        schema=schema
+    )
+
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+def test_drop_duplicates_two_columns(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates2"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [1, 1, 1, 1],
+        "col2": ["A", "A", "B", "B"],
+        "col3": ["A", "A", "A", "A"],
+        "col4": ["C", "C", "C", "C"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    levi.drop_duplicates(delta_table, ["col1","col2"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+
+    expected_pyarrow_table = pa.Table.from_pydict(
+        {
+            "col1": [1,1],
+            "col2": ["A","B"],
+            "col3": ["A","A"],
+            "col4": ["C","C"],
+        },
+        schema=schema
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+def test_drop_duplicates_raises_errors(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates2"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [1, 1, 1, 1],
+        "col2": ["A", "A", "B", "B"],
+        "col3": ["A", "A", "A", "A"],
+        "col4": ["C", "C", "C", "C"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+
+    with pytest.raises(TypeError):
+        levi.drop_duplicates(None, ["col1","col2"])             # No delta_table provided
+        levi.drop_duplicates(delta_table, [])                   # Empty duplication_columns provided
+        levi.drop_duplicates(delta_table, None)                 # No duplication_columns provided
+        levi.drop_duplicates(delta_table, ["col1","col5"])      # Non-existing col5 provided
+        levi.drop_duplicates(delta_table, "col1")               # Wrong type of duplication_columns
+
+
+
+def test_drop_duplicates_pkey_two_columns_with_sorted_pkey(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  1,   2,   3,   4,   5,   6,   9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+
+    expected_pyarrow_table = pa.Table.from_pydict(
+        {
+            "col1": [1, 2, 5, 6],
+            "col2": ["A", "A", "B", "D"],
+            "col3": ["A", "B", "B", "D"],
+            "col4": ["C", "C", "C", "C"],
+        },
+        schema=schema
+    )
+
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+
+
+def test_drop_duplicates_pkey_two_columns_with_unsorted_pkey(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  4,   2,   3,   1,   9,   6,   5],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+
+    expected_pyarrow_table = pa.Table.from_pydict(
+        {
+            "col1": [1, 2, 5, 6],
+            "col2": ["A", "A", "B", "D"],
+            "col3": ["A", "B", "B", "D"],
+            "col4": ["E", "C", "E", "C"],
+        },
+        schema=schema
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+#TODO:
+def test_drop_duplicates_pkey_with_unique_pkey(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  4,   2,   3,   1,   9,   6,   5],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+
+    expected_pyarrow_table = pa.Table.from_pydict(
+        {
+            "col1": [1, 2, 5, 6],
+            "col2": ["A", "A", "B", "D"],
+            "col3": ["A", "B", "B", "D"],
+            "col4": ["E", "C", "E", "C"],
+        },
+        schema=schema
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table    
+
+
+def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  1,   1,   3,   4,   5,   6,   9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+
+    with pytest.raises(ValueError):
+        levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
+
+def test_drop_duplicates_pkey_without_unique_pkey_raises_error(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  1,   1,   3,   4,   5,   6,   9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+
+    with pytest.raises(ValueError):
+        levi.drop_duplicates_pkey(delta_table, "col1", ["col2", "col3"])
+
+
+def test_drop_duplicates_pkey_raises_errors(tmp_path):
+
+    path = f"{tmp_path}/drop_duplicates_pkey1"
+
+    schema = pa.schema([
+        ('col1', pa.int64()),
+        ('col2', pa.string()),
+        ('col3', pa.string()),
+        ('col4', pa.string()),
+    ])
+    data = {
+        "col1": [  1,   2,   3,   4,   5,   6,   9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+
+    pyarrow_table = pa.Table.from_pydict(
+        data,
+        schema=schema
+    )
+
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+
+    with pytest.raises(TypeError):
+        levi.drop_duplicates_pkey(None, "col1", ["col1","col2"])            # No delta_table provided
+        levi.drop_duplicates_pkey(delta_table, None, ["col2", "col3"])      # No pkey provided
+        levi.drop_duplicates_pkey(delta_table, "col1", None)                # No duplication_cols provided
+        levi.drop_duplicates_pkey(delta_table, "col1", [])                  # Empty duplication_cols provided
+        levi.drop_duplicates_pkey(delta_table, "col1", ["col1", "col2"])    # Pkey in duplication_cols provided
+        levi.drop_duplicates_pkey(delta_table, "col1", ["col1", "col4"])    # Non-existing col4 provided
+        levi.drop_duplicates_pkey(delta_table, "col1", "col2")              # Wrong duplication_cols type
+        levi.drop_duplicates_pkey(delta_table, 1, ["col1","col2"])          # Wrong primary_key type provided


### PR DESCRIPTION
Closes #17 
Closes #18 

The `drop_duplicates` just takes just takes the first occurence of a duplicate to keep. We should consider if user should be allowed to pass parameter to take first or last occurrence based on some sorting column.

For `drop_duplicates_pkey` it is kinda the same. However in the mack version it's just the duplicate with the lowest primary key which is kept. Again we could let the user decided whether to keep the duplicate with lowest or highest primary key.