### PR TITLE
add md5 function

### DIFF
--- a/levi/__init__.py
+++ b/levi/__init__.py
@@ -8,7 +8,7 @@ import pyarrow.compute as pc
 import pyarrow as pa
 from pyarrow.interchange.from_dataframe import DataFrameObject
 import pyarrow.compute as pc 
-import hashlib
+from hashlib import md5
 
 def skipped_stats(delta_table, filters):
     df = delta_table.get_add_actions(flatten=True).to_pandas()
@@ -432,14 +432,8 @@ def append_md5_column(delta_table: DeltaTable, cols: List[str]) -> None:
 
     :param delta_table: <description>
     :type delta_table: DeltaTable
-    :param primary_key: <description>
-    :type primary_key: str
-    :param duplication_columns: <description>
-    :type duplication_columns: Union[List[str],Tuple[str]]
-
-    :raises TypeError: Raises type error when input arguments have a invalid type, are missing or are empty.
-    :raises ValueError: Raises value error if `primary_key` is not unique in base table.
-
+    :param cols: <description>
+    :type cols: List[str]
 
     :returns: <description>
     :rtype: None

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -1050,7 +1050,7 @@ def test_append_md5_generates_expected_hashes_string_string(tmp_path: Path):
     assert actual_pyarrow_table == expected_pyarrow_table
 
 def test_append_md5_generates_expected_hashes_string_3(tmp_path: Path):
-    path = tmp_path / "append_md5_string_string"
+    path = tmp_path / "append_md5_string3"
 
     initial_schema = pa.schema(
         [
@@ -1104,7 +1104,7 @@ def test_append_md5_generates_expected_hashes_string_3(tmp_path: Path):
 
 
 def test_append_md5_generates_expected_hashes_string(tmp_path: Path):
-    path = tmp_path / "append_md5_string_string"
+    path = tmp_path / "append_md5_string"
 
     initial_schema = pa.schema(
         [

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -1048,4 +1048,110 @@ def test_append_md5_generates_expected_hashes_string_string(tmp_path: Path):
     )
 
     assert actual_pyarrow_table == expected_pyarrow_table
-    print('passed')
+
+def test_append_md5_generates_expected_hashes_string_3(tmp_path: Path):
+    path = tmp_path / "append_md5_string_string"
+
+    initial_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+        ]
+    )
+    expected_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+            ("md5_col2_col3_col4", pa.string())
+        ]
+    )
+
+    initial_data = {
+        "col1": [1, 2, 3, 4, 5, 6, 9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+    
+    n_rows = len(initial_data["col1"])
+    expected_data = initial_data
+    expected_md5_values = []
+    for i in range(n_rows):
+        concat_val = str(initial_data["col2"][i]) + "||" + str(initial_data["col3"][i]) + "||" + str(initial_data['col4'][i])
+        hash_val = hashlib.md5(concat_val.encode("utf-8")).hexdigest()
+        expected_md5_values.append(hash_val)
+
+    expected_data["md5_col2_col3_col4"] = expected_md5_values
+    
+    pyarrow_table = pa.Table.from_pydict(initial_data, schema=initial_schema)
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+    levi.append_md5_column(delta_table, ["col2", "col3", "col4"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+    expected_pyarrow_table = pa.Table.from_pydict(
+        expected_data, 
+        schema=expected_schema,
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+
+def test_append_md5_generates_expected_hashes_string(tmp_path: Path):
+    path = tmp_path / "append_md5_string_string"
+
+    initial_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+        ]
+    )
+    expected_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+            ("md5_col2", pa.string())
+        ]
+    )
+
+    initial_data = {
+        "col1": [1, 2, 3, 4, 5, 6, 9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+    
+    n_rows = len(initial_data["col1"])
+    expected_data = initial_data
+    expected_md5_values = []
+    for i in range(n_rows):
+        concat_val = str(initial_data["col2"][i])     
+        hash_val = hashlib.md5(concat_val.encode("utf-8")).hexdigest()
+        expected_md5_values.append(hash_val)
+
+    expected_data["md5_col2"] = expected_md5_values
+    
+    pyarrow_table = pa.Table.from_pydict(initial_data, schema=initial_schema)
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+    levi.append_md5_column(delta_table, ["col2"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+    expected_pyarrow_table = pa.Table.from_pydict(
+        expected_data, 
+        schema=expected_schema,
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 import pandas as pd
 import random
 import pytest
-
+import hashlib
 
 def test_skipped_stats():
     delta_table = DeltaTable("./tests/reader_tests/generated/basic_append/delta")
@@ -942,3 +942,110 @@ def test_drop_duplicates_pkey_raises_errors(tmp_path):
         levi.drop_duplicates_pkey(delta_table, "col1", "col2")              # Wrong duplication_cols type
         levi.drop_duplicates_pkey(delta_table, 1, ["col1","col2"])          # Wrong primary_key type provided
 
+
+def test_append_md5_generates_expected_hashes_int_string(tmp_path: Path):
+    path = tmp_path / "append_md5_int_string"
+
+    initial_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+        ]
+    )
+    expected_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+            ("md5_col1_col2", pa.string())
+        ]
+    )
+
+    initial_data = {
+        "col1": [1, 2, 3, 4, 5, 6, 9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+    
+    n_rows = len(initial_data["col1"])
+    expected_data = initial_data
+    expected_md5_values = []
+    for i in range(n_rows):
+        concat_val = str(initial_data["col1"][i]) + "||" + str(initial_data['col2'][i])
+        hash_val = hashlib.md5(concat_val.encode("utf-8")).hexdigest()
+        expected_md5_values.append(hash_val)
+
+    expected_data["md5_col1_col2"] = expected_md5_values
+    
+    pyarrow_table = pa.Table.from_pydict(initial_data, schema=initial_schema)
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+    levi.append_md5_column(delta_table, ["col1", "col2"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+    expected_pyarrow_table = pa.Table.from_pydict(
+        expected_data, 
+        schema=expected_schema,
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+
+def test_append_md5_generates_expected_hashes_string_string(tmp_path: Path):
+    path = tmp_path / "append_md5_string_string"
+
+    initial_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+        ]
+    )
+    expected_schema = pa.schema(
+        [
+            ("col1", pa.int64()),
+            ("col2", pa.string()),
+            ("col3", pa.string()),
+            ("col4", pa.string()),
+            ("md5_col3_col4", pa.string())
+        ]
+    )
+
+    initial_data = {
+        "col1": [1, 2, 3, 4, 5, 6, 9],
+        "col2": ["A", "A", "A", "A", "B", "D", "B"],
+        "col3": ["A", "B", "A", "A", "B", "D", "B"],
+        "col4": ["C", "C", "D", "E", "C", "C", "E"],
+    }
+    
+    n_rows = len(initial_data["col1"])
+    expected_data = initial_data
+    expected_md5_values = []
+    for i in range(n_rows):
+        concat_val = str(initial_data["col3"][i]) + "||" + str(initial_data['col4'][i])
+        hash_val = hashlib.md5(concat_val.encode("utf-8")).hexdigest()
+        expected_md5_values.append(hash_val)
+
+    expected_data["md5_col3_col4"] = expected_md5_values
+    
+    pyarrow_table = pa.Table.from_pydict(initial_data, schema=initial_schema)
+    write_deltalake(path, pyarrow_table)
+
+    delta_table = DeltaTable(path)
+    levi.append_md5_column(delta_table, ["col3", "col4"])
+
+    actual_delta_table = DeltaTable(path)
+    actual_pyarrow_table = actual_delta_table.to_pyarrow_table()
+    expected_pyarrow_table = pa.Table.from_pydict(
+        expected_data, 
+        schema=expected_schema,
+    )
+
+    assert actual_pyarrow_table == expected_pyarrow_table
+    print('passed')


### PR DESCRIPTION
addresses #21 

I have a working implementation of an appended md5 column using the standard library `hashlib.md5` function. 

This likely won't work on larger tables as implementation includes a pylist collection and a list comprehension where the md5 hash is computed per-value before being appended to the pyarrow table. 

Open to suggestions for improvement!

---

One thing that is currently unhandled is columns containing null values. The [binary_join_element_wise](https://arrow.apache.org/docs/python/generated/pyarrow.compute.binary_join_element_wise.html) documentation has support for 
1. emitting a null for the full concatenation (default)
2. skipping the null element
3. replacing the null element with a string

I'm in favor of either 2 or 3 - let me know your thoughts

